### PR TITLE
Exporting missing symbols, fixing warnings

### DIFF
--- a/libs/core/async_mpi/src/mpi_future.cpp
+++ b/libs/core/async_mpi/src/mpi_future.cpp
@@ -81,7 +81,8 @@ namespace hpx { namespace mpi { namespace experimental {
         {
             get_requests_vector().push_back(req_callback.request);
             get_request_callback_vector().push_back(std::move(req_callback));
-            get_mpi_info().requests_vector_size_ = get_requests_vector().size();
+            get_mpi_info().requests_vector_size_ =
+                static_cast<std::uint32_t>(get_requests_vector().size());
 
             if constexpr (mpi_debug.is_enabled())
             {
@@ -340,7 +341,7 @@ namespace hpx { namespace mpi { namespace experimental {
                 }
 
                 detail::get_mpi_info().requests_vector_size_ =
-                    requests_vector.size();
+                    static_cast<std::uint32_t>(requests_vector.size());
 
                 if constexpr (mpi_debug.is_enabled())
                 {

--- a/libs/core/async_mpi/src/mpi_future.cpp
+++ b/libs/core/async_mpi/src/mpi_future.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace util {
 
         static std::string get_processor_name();
 
-        struct scoped_lock
+        struct HPX_LOCAL_EXPORT scoped_lock
         {
             scoped_lock();
             scoped_lock(scoped_lock const&) = delete;
@@ -49,7 +49,7 @@ namespace hpx { namespace util {
             void unlock();
         };
 
-        struct scoped_try_lock
+        struct HPX_LOCAL_EXPORT scoped_try_lock
         {
             scoped_try_lock();
             scoped_try_lock(scoped_try_lock const&) = delete;


### PR DESCRIPTION
This fixes some errors and warnings encountered while building using MSVC