### PR TITLE
Change default `get_function_annotation` implementation

### DIFF
--- a/libs/core/functional/include/hpx/functional/traits/get_function_annotation.hpp
+++ b/libs/core/functional/include/hpx/functional/traits/get_function_annotation.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace traits {
     {
         static constexpr char const* call(F const& /*f*/) noexcept
         {
-            return nullptr;
+            return typeid(F).name();
         }
     };
 


### PR DESCRIPTION
See https://github.com/STEllAR-GROUP/hpx/pull/5694.

This needs more work to actually implement the suggestions in https://github.com/STEllAR-GROUP/hpx/pull/5694.