### PR TITLE
Allow running resource partitioner tests with fewer than 4 threads

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -35,7 +35,7 @@ jobs:
               -DHPXLocal_WITH_EXAMPLES=ON \
               -DHPXLocal_WITH_TESTS=ON \
               -DHPXLocal_WITH_TESTS_HEADERS=OFF \
-              -DHPXLocal_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
+              -DHPXLocal_WITH_TESTS_MAX_THREADS_PER_LOCALITY=3 \
               -DHPXLocal_WITH_CHECK_MODULE_DEPENDENCIES=ON
     - name: Build
       shell: bash

--- a/libs/core/executors/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/core/executors/tests/unit/standalone_thread_pool_executor.cpp
@@ -166,7 +166,8 @@ int main()
             hpx::threads::policies::local_priority_queue_scheduler<>;
 
         // Choose all the parameters for the thread pool and scheduler.
-        std::size_t const num_threads = 4;
+        std::size_t const num_threads = (std::min)(
+            std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
         std::size_t const max_cores = num_threads;
         hpx::threads::policies::detail::affinity_data ad{};
         ad.init(num_threads, max_cores, 0, 1, 0, "core", "balanced", true);

--- a/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -7,6 +7,7 @@
 // Simple test verifying basic resource partitioner
 // pool and executor
 
+#include <hpx/assert.hpp>
 #include <hpx/local/execution.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
@@ -20,7 +21,8 @@
 #include <utility>
 #include <vector>
 
-int const max_threads = 4;
+std::size_t const max_threads = (std::min)(
+    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
 
 // dummy function we will call using async
 void dummy_task(std::size_t n, std::string const& text)
@@ -33,20 +35,21 @@ void dummy_task(std::size_t n, std::string const& text)
 
 int hpx_main()
 {
-    HPX_TEST_EQ(std::size_t(4), hpx::resource::get_num_threads());
-    HPX_TEST_EQ(std::size_t(4), hpx::resource::get_num_thread_pools());
+    HPX_TEST_EQ(std::size_t(max_threads), hpx::resource::get_num_threads());
+    HPX_TEST_EQ(
+        std::size_t(max_threads), hpx::resource::get_num_thread_pools());
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("default"));
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("pool-0"));
     HPX_TEST(hpx::resource::pool_exists("default"));
     HPX_TEST(hpx::resource::pool_exists("pool-0"));
     HPX_TEST(!hpx::resource::pool_exists("nonexistent"));
-    for (int pool_index = 0; pool_index < max_threads; ++pool_index)
+    for (std::size_t pool_index = 0; pool_index < max_threads; ++pool_index)
     {
         HPX_TEST(hpx::resource::pool_exists(pool_index));
     }
     HPX_TEST(!hpx::resource::pool_exists(max_threads));
 
-    for (int i = 0; i < max_threads; ++i)
+    for (std::size_t i = 0; i < max_threads; ++i)
     {
         std::string pool_name = "pool-" + std::to_string(i);
         HPX_TEST_EQ(pool_name, hpx::resource::get_pool_name(i));
@@ -80,7 +83,7 @@ int hpx_main()
     std::vector<hpx::execution::parallel_executor> execs;
     std::vector<hpx::execution::parallel_executor> execs_hp;
     //
-    for (int i = 0; i < max_threads; ++i)
+    for (std::size_t i = 0; i < max_threads; ++i)
     {
         std::string pool_name = "pool-" + std::to_string(i);
         execs.push_back(hpx::execution::parallel_executor(
@@ -91,7 +94,7 @@ int hpx_main()
             hpx::threads::thread_priority::high));
     }
 
-    for (int i = 0; i < max_threads; ++i)
+    for (std::size_t i = 0; i < max_threads; ++i)
     {
         std::string pool_name = "pool-" + std::to_string(i);
         lotsa_futures.push_back(
@@ -120,7 +123,7 @@ void init_resource_partitioner_handler(
     rp.set_default_pool_name("pool-0");
 
     // create N pools
-    for (int i = 0; i < max_threads; i++)
+    for (std::size_t i = 0; i < max_threads; i++)
     {
         std::string pool_name = "pool-" + std::to_string(i);
         rp.create_thread_pool(
@@ -128,7 +131,7 @@ void init_resource_partitioner_handler(
     }
 
     // add one PU to each pool
-    int thread_count = 0;
+    std::size_t thread_count = 0;
     for (hpx::resource::numa_domain const& d : rp.numa_domains())
     {
         for (hpx::resource::core const& c : d.cores())
@@ -149,9 +152,11 @@ void init_resource_partitioner_handler(
     }
 }
 
-// this test must be run with 4 threads
+// this test must be run with at least 2 threads
 int main(int argc, char* argv[])
 {
+    HPX_ASSERT(max_threads >= 2);
+
     hpx::local::init_params init_args;
     init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
     // Set the callback to init the thread_pools

--- a/libs/core/resource_partitioner/tests/unit/resource_partitioner_info.cpp
+++ b/libs/core/resource_partitioner/tests/unit/resource_partitioner_info.cpp
@@ -6,6 +6,7 @@
 
 // Simple test verifying basic resource_partitioner functionality.
 
+#include <hpx/assert.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/local/thread.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
@@ -16,10 +17,13 @@
 #include <utility>
 #include <vector>
 
+std::size_t const max_threads = (std::min)(
+    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
+
 int hpx_main()
 {
-    HPX_TEST_EQ(std::size_t(4), hpx::resource::get_num_threads());
-    HPX_TEST_EQ(std::size_t(4), hpx::resource::get_num_threads(0));
+    HPX_TEST_EQ(std::size_t(max_threads), hpx::resource::get_num_threads());
+    HPX_TEST_EQ(std::size_t(max_threads), hpx::resource::get_num_threads(0));
     HPX_TEST_EQ(std::size_t(1), hpx::resource::get_num_thread_pools());
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("default"));
     HPX_TEST_EQ(std::string("default"), hpx::resource::get_pool_name(0));
@@ -45,10 +49,12 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> cfg = {"hpx.os_threads=4"};
+    HPX_ASSERT(max_threads >= 2);
 
     hpx::local::init_params init_args;
-    init_args.cfg = std::move(cfg);
+    init_args.cfg = {"hpx.os_threads=" +
+        std::to_string(((std::min)(std::size_t(4),
+            std::size_t(hpx::threads::hardware_concurrency()))))};
 
     // now run the test
     HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);

--- a/libs/core/resource_partitioner/tests/unit/suspend_disabled.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_disabled.cpp
@@ -48,7 +48,9 @@ int main(int argc, char* argv[])
 {
     hpx::local::init_params init_args;
 
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" +
+        std::to_string(((std::min)(std::size_t(4),
+            std::size_t(hpx::threads::hardware_concurrency()))))};
     init_args.rp_callback = [](auto& rp,
                                 hpx::program_options::variables_map const&) {
         // Explicitly disable elasticity if it is in defaults

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -31,7 +31,9 @@ void test_scheduler(
 {
     hpx::local::init_params init_args;
 
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" +
+        std::to_string(((std::min)(std::size_t(4),
+            std::size_t(hpx::threads::hardware_concurrency()))))};
     init_args.rp_callback = [scheduler](auto& rp,
                                 hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);

--- a/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -24,7 +24,9 @@ void test_scheduler(
 {
     hpx::local::init_params init_args;
 
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" +
+        std::to_string(((std::min)(std::size_t(4),
+            std::size_t(hpx::threads::hardware_concurrency()))))};
     init_args.rp_callback = [scheduler](auto& rp,
                                 hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -6,6 +6,7 @@
 
 // Simple test verifying basic resource_partitioner functionality.
 
+#include <hpx/assert.hpp>
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
@@ -23,16 +24,19 @@
 #include <utility>
 #include <vector>
 
+std::size_t const max_threads = (std::min)(
+    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
+
 int hpx_main()
 {
     std::size_t const num_threads = hpx::resource::get_num_threads("default");
 
-    HPX_TEST_EQ(std::size_t(4), num_threads);
+    HPX_TEST_EQ(std::size_t(max_threads), num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("default");
 
-    HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(4));
+    HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(max_threads));
 
     {
         // Check number of used resources
@@ -118,21 +122,25 @@ int hpx_main()
 
             fs.clear();
 
-            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
+            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            {
+                fs.push_back(
+                    hpx::threads::suspend_processing_unit(tp, thread_num));
+            }
 
             hpx::wait_all(fs);
 
             fs.clear();
 
-            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
+            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            {
+                fs.push_back(
+                    hpx::threads::resume_processing_unit(tp, thread_num));
+            }
 
             hpx::wait_all(fs);
         }
@@ -154,7 +162,7 @@ int hpx_main()
 
             if (up)
             {
-                if (thread_num != hpx::resource::get_num_threads("default") - 1)
+                if (thread_num < hpx::resource::get_num_threads("default") - 1)
                 {
                     hpx::threads::suspend_processing_unit(tp, thread_num).get();
                 }
@@ -169,11 +177,13 @@ int hpx_main()
             }
             else
             {
-                hpx::threads::resume_processing_unit(tp, thread_num - 1).get();
+                hpx::threads::resume_processing_unit(tp, thread_num).get();
 
-                --thread_num;
-
-                if (thread_num == 0)
+                if (thread_num > 0)
+                {
+                    --thread_num;
+                }
+                else
                 {
                     up = true;
                 }
@@ -197,7 +207,7 @@ void test_scheduler(
     int argc, char* argv[], hpx::resource::scheduling_policy scheduler)
 {
     hpx::local::init_params init_args;
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler,
@@ -211,6 +221,8 @@ void test_scheduler(
 
 int main(int argc, char* argv[])
 {
+    HPX_ASSERT(max_threads >= 2);
+
     // NOTE: Static schedulers do not support suspending the own worker thread
     // because they do not steal work.
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -6,6 +6,7 @@
 
 // Simple test verifying basic resource_partitioner functionality.
 
+#include <hpx/assert.hpp>
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
@@ -23,11 +24,14 @@
 #include <utility>
 #include <vector>
 
+std::size_t const max_threads = (std::min)(
+    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
+
 int hpx_main()
 {
     std::size_t const num_threads = hpx::resource::get_num_threads("worker");
 
-    HPX_TEST_EQ(std::size_t(3), num_threads);
+    HPX_TEST_EQ(std::size_t(max_threads - 1), num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("worker");
@@ -71,21 +75,25 @@ int hpx_main()
 
             fs.clear();
 
-            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::suspend_processing_unit(tp, thread_num));
+            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            {
+                fs.push_back(
+                    hpx::threads::suspend_processing_unit(tp, thread_num));
+            }
 
             hpx::wait_all(fs);
 
             fs.clear();
 
-            // Launching 4 (i.e. same as number of threads) tasks may deadlock
+            // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
-            fs.push_back(hpx::threads::resume_processing_unit(tp, thread_num));
+            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            {
+                fs.push_back(
+                    hpx::threads::resume_processing_unit(tp, thread_num));
+            }
 
             hpx::wait_all(fs);
         }
@@ -122,11 +130,13 @@ int hpx_main()
             }
             else
             {
-                hpx::threads::resume_processing_unit(tp, thread_num - 1).get();
+                hpx::threads::resume_processing_unit(tp, thread_num).get();
 
-                --thread_num;
-
-                if (thread_num == 0)
+                if (thread_num > 0)
+                {
+                    --thread_num;
+                }
+                else
                 {
                     up = true;
                 }
@@ -151,7 +161,7 @@ void test_scheduler(
 {
     hpx::local::init_params init_args;
 
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 hpx::program_options::variables_map const&) {
         rp.create_thread_pool("worker", scheduler,
@@ -159,8 +169,8 @@ void test_scheduler(
                 hpx::threads::policies::default_mode |
                 hpx::threads::policies::enable_elasticity));
 
-        int const worker_pool_threads = 3;
-        int worker_pool_threads_added = 0;
+        std::size_t const worker_pool_threads = max_threads - 1;
+        std::size_t worker_pool_threads_added = 0;
 
         for (hpx::resource::numa_domain const& d : rp.numa_domains())
         {
@@ -183,6 +193,8 @@ void test_scheduler(
 
 int main(int argc, char* argv[])
 {
+    HPX_ASSERT(max_threads >= 2);
+
     std::vector<hpx::resource::scheduling_policy> schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -6,6 +6,7 @@
 
 // Simple test verifying basic resource_partitioner functionality.
 
+#include <hpx/assert.hpp>
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/execution.hpp>
 #include <hpx/local/future.hpp>
@@ -25,6 +26,9 @@
 #include <utility>
 #include <vector>
 
+std::size_t const max_threads = (std::min)(
+    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
+
 int hpx_main(int argc, char* argv[])
 {
     hpx::threads::thread_pool_base& worker_pool =
@@ -33,7 +37,7 @@ int hpx_main(int argc, char* argv[])
               << worker_pool.get_scheduler()->get_description() << std::endl;
     std::size_t const num_threads = hpx::resource::get_num_threads("default");
 
-    HPX_TEST_EQ(std::size_t(4), num_threads);
+    HPX_TEST_EQ(max_threads, num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("default");
@@ -64,7 +68,7 @@ int hpx_main(int argc, char* argv[])
 
             if (up)
             {
-                if (thread_num != hpx::resource::get_num_threads("default") - 1)
+                if (thread_num < hpx::resource::get_num_threads("default") - 1)
                 {
                     hpx::threads::suspend_processing_unit(tp, thread_num).get();
                 }
@@ -79,11 +83,13 @@ int hpx_main(int argc, char* argv[])
             }
             else
             {
-                hpx::threads::resume_processing_unit(tp, thread_num - 1).get();
+                hpx::threads::resume_processing_unit(tp, thread_num).get();
 
-                --thread_num;
-
-                if (thread_num == 0)
+                if (thread_num > 0)
+                {
+                    --thread_num;
+                }
+                else
                 {
                     up = true;
                 }
@@ -108,7 +114,7 @@ void test_scheduler(
 {
     hpx::local::init_params init_args;
 
-    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp) {
         std::cout << "\nCreating pool with scheduler " << scheduler
                   << std::endl;
@@ -124,6 +130,8 @@ void test_scheduler(
 
 int main(int argc, char* argv[])
 {
+    HPX_ASSERT(max_threads >= 2);
+
     // NOTE: Static schedulers do not support suspending the own worker thread
     // because they do not steal work. Periodic priority scheduler not tested
     // because it does not take into account scheduler states when scheduling

--- a/libs/core/resource_partitioner/tests/unit/used_pus.cpp
+++ b/libs/core/resource_partitioner/tests/unit/used_pus.cpp
@@ -36,10 +36,10 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> cfg = {"hpx.os_threads=4"};
-
     hpx::local::init_params init_args;
-    init_args.cfg = std::move(cfg);
+    init_args.cfg = {"hpx.os_threads=" +
+        std::to_string(((std::min)(std::size_t(4),
+            std::size_t(hpx::threads::hardware_concurrency()))))};
 
     // now run the test
     HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);


### PR DESCRIPTION
Most of the tests still require at least 2 threads, but that we do at least get that even on the most constrained GH actions runners.

Also fixes an "oddity" in some of the suspension tests, i.e. something that's not obviously wrong, but it's also obviously not right. The indexing in choosing which thread to suspend/resume was a bit off in the `suspend_thread*` tests. Unsure if this will fix any of the still occasionally timing out suspension tests, but it won't hurt at least.